### PR TITLE
removes code that forces filters to an array

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# For security of github workflows infrastructure must own CODEOWNERS and .github/workflows dir
+# IMPORTANT: This must be at the bottom of the CODEOWNERS file
+/.github/workflows @happyreturns/infrastructure-team
+CODEOWNERS @happyreturns/infrastructure-team

--- a/src/resources/sales_order_invoice.js
+++ b/src/resources/sales_order_invoice.js
@@ -63,16 +63,6 @@ var protos = {
   */
   list: {
     optional: 'filters',
-    modifiers: {
-      filters: function(filters) {
-        // if filters is not an array, wrap it in an array
-        if (!Array.isArray(filters)) {
-          return [ filters ];
-        }
-
-        return filters;
-      }
-    }
   }
 };
 


### PR DESCRIPTION
This was causing problems with the server figuring out the filter attribute names.  I also found other resources weren't using this logic for `.list`, so it doesn't seem necessary.